### PR TITLE
Signal Attachment Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Note that this software is currently under development, and I am not responsible
 
 * [Quinnat](https://github.com/midsum-salrux/quinnat)
 * [Semaphore](https://github.com/lwesterhof/semaphore)
+* Boto3
 * an already-registered Signal number
 * a running instance of [signald](https://gitlab.com/signald/signald) (note: this project uses the Debian package)
 * an Urbit identity
@@ -40,6 +41,10 @@ Install Quinnat via `pip`:
 Install Semaphore via `pip`:
 
 `pip3 install semaphore-bot`
+
+Install boto3 via `pip`:
+
+`pip3 install boto3`
 
 Set up a group on your Urbit for your bridge to reside in.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that this software is currently under development, and I am not responsible
 * ~~relay text messages from a Signal group to an Urbit chat~~ **COMPLETE**
 * relay text messages from an Urbit chat to a Signal group
 * relay image messages from an Urbit chat to Signal
-* relay image messages from Signal to Urbit
+* ~~relay attachments from Signal to Urbit~~ **COMPLETE**
 * provide configuration for displaying of reactions, replies, read receipts, typing notifications from Signal to Urbit
 * provide commands for viewing group metadata
 
@@ -25,6 +25,7 @@ Note that this software is currently under development, and I am not responsible
 * an already-registered Signal number
 * a running instance of [signald](https://gitlab.com/signald/signald) (note: this project uses the Debian package)
 * an Urbit identity
+* an Urbit-compatible S3 bucket
 
 ## Setup
 

--- a/example.ini
+++ b/example.ini
@@ -1,8 +1,14 @@
-[Signal]
+[S3]
+s3Url=http://127.0.0.1
+s3AccessKey=aaa
+s3SecretKey=aaa
+s3Bucket=aaa
+
+[SIGNAL]
 signalUsername = +15555555555
 signaldSocketPath = /var/run/signald/signald.sock
 
-[Urbit]
+[URBIT]
 urbitUrl = http://127.0.0.1:8080
 urbitId = zod
 urbitCode = dozzod-dozzod-dozzod-dozzod

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
-import configparser, quinnat, anyio
+import configparser, quinnat, anyio, boto3
 from semaphore import Bot, ChatContext
 
 config = configparser.ConfigParser()
 config.read('default.ini')
 
+s3Url = config['S3']['s3Url']
+s3AccessKey = config['S3']['s3AccessKey']
+s3SecretKey = config['S3']['s3SecretKey']
+s3Bucket = config['S3']['s3Bucket']
 signalUsername = config['SIGNAL']['signalUsername']
 signaldSocketPath = config['SIGNAL']['signaldSocketPath']
 urbitUrl = config['URBIT']['urbitUrl']
@@ -12,6 +16,12 @@ urbitCode = config['URBIT']['urbitCode']
 urbitBridgeChat = config['URBIT']['urbitBridgeChat']
 urbitHost = config['URBIT']['urbitHost']
 
+s3Client = boto3.resource(
+        service_name='s3',
+        aws_access_key_id=s3AccessKey,
+        aws_secret_access_key=s3SecretKey,
+        endpoint_url=s3Url
+)
 signalClient = Bot(signalUsername)
 urbitClient = quinnat.Quinnat(urbitUrl, urbitId, urbitCode)
 
@@ -20,10 +30,12 @@ async def simpleRelay(ctx: ChatContext) -> None:
     if ctx.message.data_message.group and not ctx.message.data_message.attachments:
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username} in group {ctx.message.data_message.group.name}: {ctx.message.get_body()}"})
     if ctx.message.data_message.group and ctx.message.data_message.attachments:
+        s3Client.Bucket(s3Bucket).upload_file(Filename=ctx.message.data_message.attachments[0].stored_filename, Key=ctx.message.data_message.attachments[0].id)
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"*{ctx.message.username} in group {ctx.message.data_message.group.name} sent an attachment.*"})
     if not ctx.message.data_message.group and not ctx.message.data_message.attachments:
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username}: {ctx.message.get_body()}"})
     if not ctx.message.data_message.group and ctx.message.data_message.attachments:
+        s3Client.Bucket(s3Bucket).upload_file(Filename=ctx.message.data_message.attachments[0].stored_filename, Key=ctx.message.data_message.attachments[0].id)
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"*{ctx.message.username} sent an attachment.*"})
 
 async def main():

--- a/main.py
+++ b/main.py
@@ -37,6 +37,8 @@ async def simpleRelay(ctx: ChatContext) -> None:
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username} in group {ctx.message.data_message.group.name}: {ctx.message.get_body()}"})
 
     if ctx.message.data_message.group and ctx.message.data_message.attachments:
+        if ctx.message.get_body():
+            urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username} in group {ctx.message.data_message.group.name}: {ctx.message.get_body()}"})
         for i in ctx.message.data_message.attachments:
             s3Key = i.id + '.' + parseContentType(i.content_type)
             s3Client.Bucket(s3Bucket).upload_file(
@@ -51,6 +53,8 @@ async def simpleRelay(ctx: ChatContext) -> None:
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username}: {ctx.message.get_body()}"})
 
     if not ctx.message.data_message.group and ctx.message.data_message.attachments:
+        if ctx.message.get_body():
+            urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username}: {ctx.message.get_body()}"})
         for i in ctx.message.data_message.attachments:
             s3Key = i.id + '.' + parseContentType(i.content_type)
             s3Client.Bucket(s3Bucket).upload_file(

--- a/main.py
+++ b/main.py
@@ -37,27 +37,29 @@ async def simpleRelay(ctx: ChatContext) -> None:
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username} in group {ctx.message.data_message.group.name}: {ctx.message.get_body()}"})
 
     if ctx.message.data_message.group and ctx.message.data_message.attachments:
-        s3Key = ctx.message.data_message.attachments[0].id + '.' + parseContentType(ctx.message.data_message.attachments[0].content_type)
-        s3Client.Bucket(s3Bucket).upload_file(
-                Filename = ctx.message.data_message.attachments[0].stored_filename, 
-                Key = s3Key
+        for i in ctx.message.data_message.attachments:
+            s3Key = i.id + '.' + parseContentType(i.content_type)
+            s3Client.Bucket(s3Bucket).upload_file(
+                    Filename = i.stored_filename, 
+                    Key = s3Key
             )
-        s3AttachmentUrl = s3BucketUrl + '/' + s3Key
-        urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username} in group {ctx.message.data_message.group.name}:"})
-        urbitClient.post_message(urbitHost, urbitBridgeChat, {"url": f"{s3AttachmentUrl}"})
+            s3AttachmentUrl = s3BucketUrl + '/' + s3Key
+            urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username} in group {ctx.message.data_message.group.name}:"})
+            urbitClient.post_message(urbitHost, urbitBridgeChat, {"url": f"{s3AttachmentUrl}"})
 
     if not ctx.message.data_message.group and not ctx.message.data_message.attachments:
         urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username}: {ctx.message.get_body()}"})
 
     if not ctx.message.data_message.group and ctx.message.data_message.attachments:
-        s3Key = ctx.message.data_message.attachments[0].id + '.' + parseContentType(ctx.message.data_message.attachments[0].content_type)
-        s3Client.Bucket(s3Bucket).upload_file(
-                Filename = ctx.message.data_message.attachments[0].stored_filename, 
-                Key = s3Key
+        for i in ctx.message.data_message.attachments:
+            s3Key = i.id + '.' + parseContentType(i.content_type)
+            s3Client.Bucket(s3Bucket).upload_file(
+                    Filename = i.stored_filename, 
+                    Key = s3Key
             )
-        s3AttachmentUrl = s3BucketUrl + '/' + s3Key
-        urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username}:"})
-        urbitClient.post_message(urbitHost, urbitBridgeChat, {"url": f"{s3AttachmentUrl}"})
+            s3AttachmentUrl = s3BucketUrl + '/' + s3Key
+            urbitClient.post_message(urbitHost, urbitBridgeChat, {"text": f"{ctx.message.username}:"})
+            urbitClient.post_message(urbitHost, urbitBridgeChat, {"url": f"{s3AttachmentUrl}"})
 
 async def main():
     urbitClient.connect()


### PR DESCRIPTION
This PR adds support for relaying Signal attachments to an S3 bucket, then posting the attachments' link to Urbit.

Note that any attachments uploaded to the S3 bucket will not have Signal's end-to-end encryption, and will (due to Urbit's S3 requirements) be publicly-viewable.